### PR TITLE
⬆️ Bump Gitlab CI utils to version 2.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.1.0] - 2022-01-27
+### Changed
+- Bump version of Gitlab CI utils to 2.10.0
+
 ## [4.0.0] - 2021-11-09
 ### Added
 - `helper_functions.sh` download

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL tag="ackee-gitlab" \
       author="Ackee 🦄" \
       description="Tailor-made image for our stack"
 
-ENV GITLAB_CI_UTILS_VERSION "2.7.0"
+ENV GITLAB_CI_UTILS_VERSION "2.10.0"
 ENV PATH "$PATH:/opt/google-cloud-sdk/bin"
 
 RUN apk add --no-cache bash coreutils curl jq git python3 rsync zip py3-pip gettext


### PR DESCRIPTION
Related: #67681